### PR TITLE
docs(deploy): note hono override for consumers

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -12,6 +12,30 @@ Neo MCP supports two runtime modes:
 - Outbound access to the selected Neo RPC endpoint
 - Controlled persistent storage when wallet records are enabled
 
+### Dependency override for installs from npm
+
+This repository pins `@hono/node-server` to `^2.0.5` through `overrides`, so installs from
+this checkout and the published container images resolve the patched line. npm does not
+propagate `overrides` to downstream installers: if you add `@r3e/neo-mcp` as a dependency
+of your own project, npm resolves `@hono/node-server` through the MCP SDK's declared
+`^1.19.9` range instead, and `npm audit` reports GHSA-frvp-7c67-39w9.
+
+That advisory covers path traversal through encoded backslashes in `serveStatic` on
+Windows. Neither this server nor the SDK transport it uses calls `serveStatic`, so the
+vulnerable code is not reachable through the Neo MCP surface, and the SDK's range cannot
+resolve to a patched version on its own. To keep the finding out of your own audit, repeat
+the override in the consuming project:
+
+```json
+{
+  "overrides": {
+    "@hono/node-server": "^2.0.5"
+  }
+}
+```
+
+Drop the override once the MCP SDK widens its range to the patched line.
+
 ## MCP Stdio
 
 The stdio server supports `NEO_NETWORK=mainnet`, `testnet`, or `both`:

--- a/tests/dependency-hardening.test.ts
+++ b/tests/dependency-hardening.test.ts
@@ -158,4 +158,70 @@ describe('dependency hardening', () => {
       expect(installIndex).toBeGreaterThan(copyIndex);
     }
   );
+
+  // GHSA-frvp-7c67-39w9: @hono/node-server < 2.0.5 resolves encoded backslashes in
+  // serveStatic paths on Windows. The MCP SDK's streamableHttp transport - the one this
+  // server runs on - depends on `^1.19.9`, a range that can never reach the patched line,
+  // and npm does not propagate `overrides` to downstream installers. So our own installs
+  // and images are patched by the override below, while anyone who runs
+  // `npm install @r3e/neo-mcp` inherits the vulnerable copy and sees the advisory. These
+  // checks keep the override in place and keep that asymmetry documented.
+  describe('hono node server advisory', () => {
+    const MINIMUM_PATCHED_HONO = [2, 0, 5] as const;
+
+    function isAtLeastHonoPatched(version: string): boolean {
+      const parsed = parseVersion(version);
+      for (let index = 0; index < MINIMUM_PATCHED_HONO.length; index += 1) {
+        const actual = parsed[index] ?? 0;
+        const required = MINIMUM_PATCHED_HONO[index];
+        if (actual > required) return true;
+        if (actual < required) return false;
+      }
+      return true;
+    }
+
+    test('overrides the transport dependency onto the patched line', () => {
+      const override = packageJson.overrides['@hono/node-server'];
+
+      expect(typeof override).toBe('string');
+      expect(isAtLeastHonoPatched((override as string).replace(/^[^0-9]*/, ''))).toBe(true);
+    });
+
+    test('installs no @hono/node-server copy below the patched version', () => {
+      const vulnerable = collectInstalledManifests(repoRoot)
+        .map((manifestPath) => ({
+          manifestPath,
+          manifest: JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+            name?: string;
+            version?: string;
+          },
+        }))
+        .filter(({ manifest }) => manifest.name === '@hono/node-server')
+        .filter(({ manifest }) => !isAtLeastHonoPatched(manifest.version ?? '0.0.0'))
+        .map(
+          ({ manifest, manifestPath }) =>
+            `${path.relative(repoRoot, manifestPath)} @ ${manifest.version}`
+        );
+
+      expect(vulnerable).toEqual([]);
+    });
+
+    test('never reaches the serveStatic surface the advisory covers', () => {
+      const sources = fs
+        .readdirSync(path.join(repoRoot, 'src'), { recursive: true, encoding: 'utf8' })
+        .filter((entry) => entry.endsWith('.ts'))
+        .map((entry) => fs.readFileSync(path.join(repoRoot, 'src', entry), 'utf8'));
+
+      expect(sources.length).toBeGreaterThan(0);
+      expect(sources.filter((source) => /serveStatic|serve-static/.test(source))).toEqual([]);
+    });
+
+    test('tells downstream installers to apply the override themselves', () => {
+      const guide = fs.readFileSync(path.join(repoRoot, 'docs', 'DEPLOYMENT.md'), 'utf8');
+
+      expect(guide).toContain('GHSA-frvp-7c67-39w9');
+      expect(guide).toContain('@hono/node-server');
+      expect(guide).toContain('overrides');
+    });
+  });
 });


### PR DESCRIPTION
`overrides` pins `@hono/node-server` to the patched `^2.0.5` line for this checkout, the container images, and the production install (all resolve 2.0.12). npm does not propagate `overrides` downstream, and the MCP SDK declares `^1.19.9`, so consumers of `@r3e/neo-mcp` resolve a vulnerable copy and see GHSA-frvp-7c67-39w9 in their own audit.

The advisory covers `serveStatic` path traversal on Windows. Neither this server nor the SDK transport it uses calls `serveStatic`, so the affected code is unreachable through the Neo MCP surface.

## Changes
- `docs/DEPLOYMENT.md`: document the asymmetry, give consumers the override to repeat, state when to drop it.
- `tests/dependency-hardening.test.ts`: four checks pin the override, reject any unpatched copy in the installed tree, assert no `serveStatic` reference enters `src/`, and fail if the guidance leaves the deployment guide.

## Verification
- `type-check` exit 0, `build` exit 0
- unit suite 53 suites / 1247 tests passed (was 1243)
- `test:mcp` 4 suites / 43 tests passed
- `npm audit --audit-level=high` and `--omit=dev --audit-level=high`: 0 vulnerabilities
- no runtime change: `src/` untouched