### PR TITLE
docs(deploy): document in-place upgrade order

### DIFF
--- a/DEPLOY_TO_HETZNER.md
+++ b/DEPLOY_TO_HETZNER.md
@@ -61,17 +61,31 @@ MCP_HTTP_BEARER=<secret>
 
 ## 3. 发布新版本
 
+**顺序不能改。** `npm run build` 的 `clean` 会**先删掉 `dist/`**，然后才用 `tsc` 编译，而
+`typescript` 是 `devDependencies`。生产上 `node_modules` 是裁剪过的（只有生产依赖），所以
+一旦跳过完整安装直接 build，就是先把正在跑的代码删掉、再以 `tsc: not found` 失败，服务只能对着
+空的 `dist/` 反复重启；把同样两条命令再跑一遍当回滚也一样失败——缺的是编译器，不是版本。
+
 ```bash
 ssh root@95.216.148.60
 cd /opt/neo-mcp
-git pull --ff-only
-npm ci --omit=dev=false
+git fetch origin --prune
+git reset --hard origin/master     # /opt/neo-mcp 是部署检出，不保留本地改动
+
+npm ci                             # 完整安装，dev 依赖提供 tsc
 npm run build                      # clean + tsc，会重建 dist/
+test -f dist/mcp-http.js           # 失败就停在这里：旧的 dist/ 已经没了
+npm prune --omit=dev               # 回到只有生产依赖；dist/ 不受影响
+
 sudo systemctl restart neo-mcp
 journalctl -u neo-mcp -n 50 --no-pager
 ```
 
 `Restart=always` 会掩盖启动期崩溃（服务看着在跑，其实在反复重启），所以 `journalctl` 这一步不能省。
+
+不要写 `npm ci --omit=dev=false`：`--omit` 只接受 `dev|optional|peer`，npm 会报
+`invalid config` 并忽略整个参数，看起来能用纯属巧合；而有人把它「修正」成 `--omit=dev`，
+下一次 build 就会把生产打挂。要装全量就写裸的 `npm ci`。
 
 ## 4. nginx 与证书
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -226,6 +226,33 @@ sudo chmod 0600 /etc/neo-mcp.env
 sudo systemctl enable --now neo-mcp
 ```
 
+## Upgrading an Existing Deployment
+
+`npm run build` runs `clean` first, which deletes `dist/`, and then compiles with `tsc`
+from `devDependencies`. A host that installed with `npm ci --omit=dev` — the normal steady
+state for a production checkout — has no `tsc`, so the clean succeeds, the compile fails
+with `tsc: not found`, and the service restarts onto an empty `dist/`. Running the same two
+commands again as a rollback fails the same way, because the missing compiler is the cause
+rather than the revision. Install the full tree, build, then prune back:
+
+```bash
+cd /opt/neo-mcp
+git fetch origin --prune
+git reset --hard origin/master
+
+npm ci                    # full install: devDependencies supply tsc
+npm run build             # clean + compile
+test -f dist/mcp-http.js  # stop here if this fails; the old build is already gone
+npm prune --omit=dev      # production-only tree again; dist/ is untouched
+
+sudo systemctl restart neo-mcp
+journalctl -u neo-mcp -n 50 --no-pager
+```
+
+Build somewhere else and copy `dist/` in if a host must never hold devDependencies.
+Container deployments avoid the problem entirely, since each image is built from a clean
+context and rolled back by pinning the previous digest.
+
 ## Health and Operations
 
 `GET /live` is the unauthenticated process liveness route used by the container health check. It does not call Neo RPC.

--- a/tests/deployment-upgrade-docs.test.ts
+++ b/tests/deployment-upgrade-docs.test.ts
@@ -36,6 +36,23 @@ function readUpgradeCommandBlock(): string {
   return fence[1];
 }
 
+const HETZNER_RELEASE_HEADING = '## 3. 发布新版本';
+
+function readHetznerReleaseBlock(): string {
+  const guide = fs.readFileSync(path.join(repoRoot, 'DEPLOY_TO_HETZNER.md'), 'utf8');
+  const start = guide.indexOf(HETZNER_RELEASE_HEADING);
+  if (start < 0) {
+    throw new Error(`DEPLOY_TO_HETZNER.md is missing the "${HETZNER_RELEASE_HEADING}" section`);
+  }
+  const next = guide.indexOf('\n## ', start + HETZNER_RELEASE_HEADING.length);
+  const section = next < 0 ? guide.slice(start) : guide.slice(start, next);
+  const fence = /```(?:bash|sh|console)?\n([\s\S]*?)```/.exec(section);
+  if (!fence) {
+    throw new Error(`the "${HETZNER_RELEASE_HEADING}" section has no fenced command block`);
+  }
+  return fence[1];
+}
+
 describe('in-place upgrade documentation', () => {
   test('build script still deletes dist and depends on a dev-only compiler', () => {
     const manifest = JSON.parse(
@@ -85,5 +102,41 @@ describe('in-place upgrade documentation', () => {
 
     expect(verify).toBeGreaterThanOrEqual(0);
     expect(restart).toBeGreaterThan(verify);
+  });
+});
+
+// The Hetzner runbook is what an operator actually follows on the host that runs the
+// service, so it has to carry the same order as the generic guide.
+describe('Hetzner release runbook', () => {
+  test('uses no invalid npm omit syntax', () => {
+    const block = readHetznerReleaseBlock();
+
+    // `--omit=dev=false` is not a valid value: npm warns "invalid config" and ignores the
+    // flag, so it only happens to install dev dependencies. Anyone "correcting" it to
+    // `--omit=dev` would strip tsc and take the host down on the next build.
+    expect(block).not.toContain('--omit=dev=false');
+    expect(block).not.toMatch(/npm ci[^\n]*--omit=dev(?!\S)/);
+  });
+
+  test('installs the full tree, builds, verifies, then prunes before restarting', () => {
+    const block = readHetznerReleaseBlock();
+
+    const install = block.search(/^\s*npm ci\s*(#|$)/m);
+    const build = block.indexOf('npm run build');
+    const verify = block.indexOf('dist/mcp-http.js');
+    const prune = block.indexOf('npm prune --omit=dev');
+    const restart = block.indexOf('systemctl restart');
+
+    expect(install).toBeGreaterThanOrEqual(0);
+    expect(build).toBeGreaterThan(install);
+    expect(verify).toBeGreaterThan(build);
+    expect(prune).toBeGreaterThan(verify);
+    expect(restart).toBeGreaterThan(prune);
+  });
+
+  test('resets to the tracked remote instead of pulling into a drifted checkout', () => {
+    const block = readHetznerReleaseBlock();
+
+    expect(block).toContain('git reset --hard origin/master');
   });
 });

--- a/tests/deployment-upgrade-docs.test.ts
+++ b/tests/deployment-upgrade-docs.test.ts
@@ -1,0 +1,89 @@
+import fs from 'fs';
+import path from 'path';
+
+// `npm run build` runs `clean` first, which deletes dist/, and then needs `tsc` from
+// devDependencies. A host whose node_modules was pruned to production deps therefore
+// loses the running build and cannot produce a new one: the clean succeeds, tsc is
+// missing, and the service restarts onto an empty dist/. Repeating the same two commands
+// as a rollback fails identically. The deployment guide has to spell out the full-install
+// -> build -> prune order so an in-place upgrade cannot take a host down this way.
+const repoRoot = path.resolve(__dirname, '..');
+
+const UPGRADE_HEADING = '## Upgrading an Existing Deployment';
+
+function readDeploymentGuide(): string {
+  return fs.readFileSync(path.join(repoRoot, 'docs', 'DEPLOYMENT.md'), 'utf8');
+}
+
+function readUpgradeSection(): string {
+  const guide = readDeploymentGuide();
+  const start = guide.indexOf(UPGRADE_HEADING);
+  if (start < 0) {
+    throw new Error(`docs/DEPLOYMENT.md is missing the "${UPGRADE_HEADING}" section`);
+  }
+  const next = guide.indexOf('\n## ', start + UPGRADE_HEADING.length);
+  return next < 0 ? guide.slice(start) : guide.slice(start, next);
+}
+
+// The prose above the commands names the failure mode first, so ordering has to be
+// asserted against the runnable block rather than the whole section.
+function readUpgradeCommandBlock(): string {
+  const section = readUpgradeSection();
+  const fence = /```(?:bash|sh|console)?\n([\s\S]*?)```/.exec(section);
+  if (!fence) {
+    throw new Error(`the "${UPGRADE_HEADING}" section has no fenced command block`);
+  }
+  return fence[1];
+}
+
+describe('in-place upgrade documentation', () => {
+  test('build script still deletes dist and depends on a dev-only compiler', () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')
+    ) as {
+      scripts: Record<string, string>;
+      devDependencies: Record<string, string>;
+      dependencies: Record<string, string>;
+    };
+
+    expect(manifest.scripts.build).toContain('clean');
+    expect(manifest.scripts.build).toContain('tsc');
+    expect(manifest.scripts.clean).toContain('rmSync');
+    expect(manifest.devDependencies.typescript).toBeDefined();
+    expect(manifest.dependencies.typescript).toBeUndefined();
+  });
+
+  test('guide documents the upgrade order for an existing deployment', () => {
+    expect(readDeploymentGuide()).toContain(UPGRADE_HEADING);
+    expect(readUpgradeSection()).toContain('npm prune --omit=dev');
+  });
+
+  test('commands order the full install before the build and the prune after it', () => {
+    const block = readUpgradeCommandBlock();
+
+    const install = block.search(/^\s*npm ci\s*(#|$)/m);
+    const build = block.indexOf('npm run build');
+    const prune = block.indexOf('npm prune --omit=dev');
+
+    expect(install).toBeGreaterThanOrEqual(0);
+    expect(build).toBeGreaterThan(install);
+    expect(prune).toBeGreaterThan(build);
+  });
+
+  test('guide warns against installing without dev dependencies before building', () => {
+    const section = readUpgradeSection();
+
+    expect(section).toContain('npm ci --omit=dev');
+    expect(section).toMatch(/tsc: not found|tsc` is missing|without `tsc`/);
+  });
+
+  test('commands verify dist before restarting the service', () => {
+    const block = readUpgradeCommandBlock();
+
+    const verify = block.indexOf('dist/mcp-http.js');
+    const restart = block.indexOf('systemctl restart');
+
+    expect(verify).toBeGreaterThanOrEqual(0);
+    expect(restart).toBeGreaterThan(verify);
+  });
+});


### PR DESCRIPTION
`npm run build` deletes `dist/` in its `clean` step and then compiles with `tsc` from `devDependencies`. A production checkout in steady state (`npm ci --omit=dev`) has no `tsc`, so an in-place upgrade deletes the running build and then fails with `tsc: not found` — and re-running the same two commands as a rollback fails identically, because the missing compiler rather than the revision is the cause.

## Changes

- `docs/DEPLOYMENT.md`: new **Upgrading an Existing Deployment** section with the working order — full `npm ci` -> `npm run build` -> verify `dist/mcp-http.js` -> `npm prune --omit=dev` -> restart — plus the build-elsewhere and container alternatives.
- `tests/deployment-upgrade-docs.test.ts`: 5 tests pinning the guidance, including that the packaging assumptions it describes (`build` cleans, `tsc` is dev-only) still hold, so the section cannot drift out of sync with `package.json`.

## Verification

- `npm run type-check` clean
- `npm test`: 54 suites / 1252 tests passing
- `npm run build` clean, `npm run test:mcp`: 4 suites / 43 tests passing
- `npm audit --audit-level=high` and `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities

Docs and tests only; no runtime code touched.